### PR TITLE
Fix 3.0 project template

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,4 +1,4 @@
-APP_NAME=Masonite 2.3
+APP_NAME=Masonite 3.0
 APP_ENV=local
 APP_DEBUG=True
 AUTH_GUARD=web

--- a/config/application.py
+++ b/config/application.py
@@ -10,7 +10,7 @@ framework needs to place the application's name in a notification or
 any other location as required by the application or its packages.
 """
 
-NAME = env("APP_NAME", "Masonite 2.3")
+NAME = env("APP_NAME", "Masonite 3.0")
 
 """Application Debug Mode
 When your application is in debug mode, detailed error messages with

--- a/config/providers.py
+++ b/config/providers.py
@@ -17,8 +17,6 @@ from masonite.providers import (
     ViewProvider,
     WhitenoiseProvider,
 )
-from masonite.validation.providers.ValidationProvider import ValidationProvider
-
 from masonite.logging.providers import LoggingProvider
 from masonite.validation.providers import ValidationProvider
 

--- a/wsgi.py
+++ b/wsgi.py
@@ -5,9 +5,8 @@ from masonite.environment import LoadEnvironment
 LoadEnvironment()
 
 from masonite.app import App
-
+from masonite.helpers import config
 from masonite.wsgi import response_handler
-from config import application, providers
 
 """Instantiate Container And Perform Important Bindings
 Some Service providers need important bindings like the WSGI application


### PR DESCRIPTION
Here is a fix for newly created 3.0 projects

I did not pay attention that `craft new` was creating 2.X project even with Masonite 3.0 so I ran:
```craft new -b 3.0``` 
and here I got an issue because there is a missing import in wsgi.py file