### PR TITLE
Change the default mail config

### DIFF
--- a/config/mail.py
+++ b/config/mail.py
@@ -1,6 +1,8 @@
 from masonite.environment import env
 
 
+FROM_EMAIL = env("FROM_EMAIL", "no-reply@masonite.com")
+
 DRIVERS = {
     "default": env("MAIL_DRIVER", "terminal"),
     "smtp": {
@@ -8,9 +10,14 @@ DRIVERS = {
         "port": env("MAIL_PORT"),
         "username": env("MAIL_USERNAME"),
         "password": env("MAIL_PASSWORD"),
+        "from": FROM_EMAIL,
     },
     "mailgun": {
         "domain": env("MAILGUN_DOMAIN"),
         "secret": env("MAILGUN_SECRET"),
+        "from": FROM_EMAIL,
+    },
+    "terminal": {
+        "from": FROM_EMAIL,
     },
 }

--- a/config/mail.py
+++ b/config/mail.py
@@ -1,7 +1,7 @@
 from masonite.environment import env
 
 
-FROM_EMAIL = env("FROM_EMAIL", "no-reply@masonite.com")
+FROM_EMAIL = env("MAIL_FROM", "no-reply@masonite.com")
 
 DRIVERS = {
     "default": env("MAIL_DRIVER", "terminal"),


### PR DESCRIPTION
As `terminal` is the default driver, "from" email should be populated to avoid an error when sending the first email.
Also from email should be specified "per driver" so here I propose a new default configuration !