### PR TITLE
Avoid using hard-coded config path

### DIFF
--- a/Kernel.py
+++ b/Kernel.py
@@ -13,7 +13,6 @@ from masonite.middleware import (
 from masonite.routes import Route
 from masonite.configuration.Configuration import Configuration
 from masonite.configuration import config
-from config.filesystem import STATICFILES
 
 from app.middlewares.VerifyCsrfToken import VerifyCsrfToken
 
@@ -100,7 +99,7 @@ class Kernel:
 
     def register_storage(self):
         storage = StorageCapsule()
-        storage.add_storage_assets(STATICFILES)
+        storage.add_storage_assets(config("filesystem.staticfiles"))
         self.application.bind("storage_capsule", storage)
 
         self.application.set_response_handler(response_handler)


### PR DESCRIPTION
Here we should prefer using config system than directly importing from config directory.