### PR TITLE
Fix compiling assets in production

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -10,6 +10,9 @@ mix.js('resources/js/app.js', 'storage/compiled/js')
     //
   ])
 
+// ensure root directory of mix is project root
+mix.setPublicPath(".")
+
 // add an alias to js code
 mix.alias({
   "@": path.resolve("resources/js/"),


### PR DESCRIPTION
cf https://laravel-mix.com/docs/6.0/api#setpublicpathpath

if we don't do that, in production (`NODE_ENV=production`) compiling assets will raise an error, because root will be server root and paths won't exist.